### PR TITLE
[SDK-284] Publish tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           packages-config-file: "lerna.json"
-          npm-registry: "npm.ops.vertexvis.io"
-          npm-auth-token: ${{ secrets.PRIVATE_NPM_AUTH_TOKEN }}
+          npm-auth-token: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "msjsdiag.debugger-for-chrome"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    { "language": "typescript", "autoFix": true },
+    { "language": "typescriptreact", "autoFix": true }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This repository contains a script to generate a VS Code workspace file. With VS
 Code workspaces, extensions are run within the context of sub-projects, so
 features like Jest debugging still work.
 
-The workspace file will be created automatically when running `rush install`.
-Otherwise you can generate the file manually by running `rush generate:vscode-workspace`.
+The workspace file will be created automatically when running `yarn install`.
+Otherwise you can generate the file manually by running `yarn generate:vscode-workspace`.
 
 Running `code ./vertex-web-tools.code-workspace` will open VS Code workspace.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # Vertex Web Monorepo
 
 Welcome to the Vertex Web repo. This is a monorepo that contains our front-end
-projects at Vertex.
+tooling at Vertex.
 
 ## Structure
 
 - `./packages`: The packages to be made available on NPM. This directory contains
   subdirectories that represent different categories of packages:
-  - `./libs`: The libs directory contains libraries that are intended to be
-    reusable across other applications and/or libraries. These are normally
-    published to our private NPM repository.
-  - `./sdks`: The sdks directory contains NPM packages for Vertex's public facing
-    SDKs.
   - `./tools`: The tools directory contains tooling libraries. Examples of these
     would be sharable tools to compile projects to JS or sharable linting
     configuration.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "typescript": "^3.7.4"
   },
   "scripts": {
+    "postinstall": "yarn generate:vscode-workspace",
+    "generate:vscode-workspace": "./scripts/generate_vscode_workspace.sh",
     "build": "lerna run build",
     "change": "lerna version --no-push --no-git-tag-version --exact",
     "release": "./scripts/release.sh",

--- a/packages/tools/build-tools/package.json
+++ b/packages/tools/build-tools/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/bundle.esm.js",
   "typings": "./dist/index.d.ts",
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "license": "UNLICENSED",
   "sideEffects": false,

--- a/packages/tools/eslint-config-vertexvis-typescript/package.json
+++ b/packages/tools/eslint-config-vertexvis-typescript/package.json
@@ -11,7 +11,8 @@
     }
   ],
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "license": "UNLICENSED",
   "main": "./index.js",

--- a/packages/tools/eslint-config-vertexvis/package.json
+++ b/packages/tools/eslint-config-vertexvis/package.json
@@ -11,7 +11,8 @@
     }
   ],
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "license": "UNLICENSED",
   "main": "./index.js",

--- a/packages/tools/jest-config-vertexvis/package.json
+++ b/packages/tools/jest-config-vertexvis/package.json
@@ -13,7 +13,8 @@
   ],
   "license": "UNLICENSED",
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "scripts": {
     "build": "exit 0",

--- a/packages/tools/rollup-plugin-vertexvis-copyright/package.json
+++ b/packages/tools/rollup-plugin-vertexvis-copyright/package.json
@@ -8,7 +8,8 @@
   "module": "./dist/bundle.esm.js",
   "typings": "./dist/index.d.ts",
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "sideEffects": false,
   "files": [

--- a/packages/tools/typescript-config-vertexvis/package.json
+++ b/packages/tools/typescript-config-vertexvis/package.json
@@ -4,7 +4,8 @@
   "description": "Sharable TypeScript configs for Vertex",
   "author": "Dan Schultz (https://github.com/danschultz)",
   "publishConfig": {
-    "registry": "https://npm.ops.vertexvis.io/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "license": "UNLICENSED",
   "files": [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Check that the release is being created from master
-if ! test -n "$(git branch | grep -E '^[*] master$')"
+if test -z "$(git branch | grep -E '^[*] master$')"
 then
   echo "Release branch must be created from master."
   exit 1
@@ -21,13 +21,16 @@ then
   exit 1
 fi
 
+# Ensure remote tags are pulled before running `lerna version` 
+git pull
+
 remote_tags=`git ls-remote --tags`
 timestamp=$(date "+%s")
 local_branch=release-$timestamp
 git checkout -tb $local_branch
 
 yarn change
-message="Releasing Change\n"
+message="Release Changes\n"
 packages=`cat lerna.json | jq -r '.packages[]'`
 package_directories=($packages)
 
@@ -39,7 +42,7 @@ for package_path in "${package_directories[@]}"; do
 
   if ! test -n "$(grep $package_tag <<< $remote_tags)"
   then
-    message+="Release $package_name v$package_version\n"
+    message+="$package_name v$package_version\n"
   fi
 done
 


### PR DESCRIPTION
## What

Publishes the existing tooling packages to the public NPM registry.

Additionally, this PR makes some changes to the scripts in the `scripts/` directory:
- Small wording updates to the `release.sh` script and adds a pull to ensure we have the correct tags locally before a `lerna version`
- Restored functionality to the `generate_vscode_workspace.sh` script
