### PR TITLE
[SDK-800] Fix dev deps that should be regular deps

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -31,6 +31,7 @@
     "test:coverage": "echo 'No unit tests defined'"
   },
   "dependencies": {
+    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.1.3",
     "rollup": "^1.19.4",
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -42,7 +43,6 @@
   "devDependencies": {
     "@types/node": "^12.6.8",
     "@vertexvis/eslint-config-vertexvis-typescript": "0.2.3",
-    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.1.3",
     "eslint": "^6.1.0",
     "tslib": "^1.10.0",
     "typescript": "^3.7.4"

--- a/packages/jest-config-vertexvis/package.json
+++ b/packages/jest-config-vertexvis/package.json
@@ -21,9 +21,11 @@
     "format": "yarn lint --fix",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx --ignore-path ../../.gitignore ."
   },
+  "dependencies": {
+    "@vertexvis/typescript-config-vertexvis": "1.0.2"
+  },
   "devDependencies": {
     "@vertexvis/eslint-config-vertexvis-typescript": "0.2.3",
-    "@vertexvis/typescript-config-vertexvis": "1.0.2",
     "eslint": "^6.1.0"
   }
 }


### PR DESCRIPTION
## What

Some dev dependencies should be regular dependencies. Needed for tests in https://github.com/Vertexvis/vertex-web-sdk/pull/44.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-800

## Test Plan

N/A

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A

## Feedback

N/A
