### PR TITLE
[SDK-1041] Correct placement of autoExternal plugin

### DIFF
--- a/packages/build-tools/src/rollup/config.ts
+++ b/packages/build-tools/src/rollup/config.ts
@@ -32,7 +32,7 @@ import { RollupConfig, RollupConfigBuilder } from './types';
  * ```
  */
 export default (...configBuilders: RollupConfigBuilder[]): RollupConfig =>
-  buildConfig(...configBuilders, autoExternal());
+  buildConfig(autoExternal(), ...configBuilders);
 
 const buildConfig = (...configBuilders: RollupConfigBuilder[]): RollupConfig =>
   configBuilders.reduce(


### PR DESCRIPTION
## What

Corrects an issue where the `autoExternal` plugin settings would always be overwritten with defaults.

## Ticket

https://vertexvis.atlassian.net/browse/SDK-1041

## Test Plan

- Test specifying `{ peerDependencies: false }` for this plugin w/ tslib

## Areas of Possible Regression

N/A

## Out of scope changes made in PR

N/A

## Dependencies

N/A

## Feedback

@Vertexvis/sdk 
PTAL
