### PR TITLE
[API-1867] Fix incorrect package detection in publish script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 .github/CODEOWNERS @danschultz
-* @vertexvis/sdk
+* @vertexvis/platform

--- a/scripts/post_download_artifacts.sh
+++ b/scripts/post_download_artifacts.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-packages=`cat lerna.json | jq -r '.packages[]'`
+packages=`cat package.json | jq -r '.workspaces[]'`
 package_directories=($packages)
 
-for package_path in "${package_directories[@]}"; do 
+for package_path in "${package_directories[@]}"; do
   dist_directory="dist/$package_path/dist"
 
   if test -d $dist_directory; then
     cp -r $dist_directory/ $package_path/dist
-  else 
+  else
     echo "Package at path $package_path does not have a dist directory. Skipping."
   fi
 done

--- a/scripts/pre_upload_artifacts.sh
+++ b/scripts/pre_upload_artifacts.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-packages=`cat lerna.json | jq -r '.packages[]'`
+packages=`cat package.json | jq -r '.workspaces[]'`
 package_directories=($packages)
 
 mkdir dist
 
-for package_path in "${package_directories[@]}"; do 
+for package_path in "${package_directories[@]}"; do
   dist_directory="$package_path/dist"
 
   if test -d $dist_directory; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,7 +21,7 @@ then
   exit 1
 fi
 
-# Ensure remote tags are pulled before running `lerna version` 
+# Ensure remote tags are pulled before running `lerna version`
 git pull
 
 remote_tags=`git ls-remote --tags`
@@ -31,10 +31,10 @@ git checkout -tb $local_branch
 
 yarn change
 message="Release Changes\n"
-packages=`cat lerna.json | jq -r '.packages[]'`
+packages=`cat package.json | jq -r '.workspaces[]'`
 package_directories=($packages)
 
-for package_path in "${package_directories[@]}"; do 
+for package_path in "${package_directories[@]}"; do
   package_json="$package_path/package.json"
   package_name=`jq '.name' -r $package_json`
   package_version=`jq '.version' -r $package_json`


### PR DESCRIPTION
## What

Should fix a bug after changing to Yarn workspaces that caused our publish stage to fail in CI. This updates scripts to find packages using Yarn workspace package definitions.

## Ticket

https://vertexvis.atlassian.net/browse/API-1867