### PR TITLE
[API-2273] Fix automated publishing of packages

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -46,5 +46,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          packages-config-file: "lerna.json"
+          packages-config-file: "package.json"
           npm-auth-token: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
## What

Publishing broke after switching to Yarn workspaces. The "packages" definition is now in `package.json` vs `lerna.json`.

## Ticket

https://vertexvis.atlassian.net/browse/API-2273

## Test Plan

<!-- Describe how your changes should be tested. -->

## Areas of Possible Regression

<!-- Features that may be impacted by these changes. -->

## Out of scope changes made in PR

<!-- Other bugs or features also included in this PR. -->

## Dependencies

<!-- Link to other PRs or tickets. -->

## Feedback

<!-- Mention the people or team you'd like to get feedback from. Explain the type of feedback you're looking for. -->
