### PR TITLE
Release new versions of packages

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/build-tools",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Build tools for web development",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -51,15 +51,15 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
-    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.4.3",
+    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.5.0",
     "rollup-plugin-typescript2": "^0.37.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^22.20.0",
     "@types/rollup-plugin-peer-deps-external": "^2.2.6",
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.5.2",
-    "@vertexvis/jest-config-vertexvis": "0.5.6",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.0",
+    "@vertexvis/jest-config-vertexvis": "0.6.0",
     "eslint": "^8.6.0",
     "jest": "^30.4.2",
     "rollup": "^4.62.2",

--- a/packages/eslint-config-vertexvis-typescript/package.json
+++ b/packages/eslint-config-vertexvis-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/eslint-config-vertexvis-typescript",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "The Vertex sharable ESLint config for TypeScript.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",
-    "@vertexvis/eslint-config-vertexvis": "0.7.2",
+    "@vertexvis/eslint-config-vertexvis": "0.8.0",
     "eslint-config-prettier": "^10.1.8"
   },
   "devDependencies": {

--- a/packages/eslint-config-vertexvis/package.json
+++ b/packages/eslint-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/eslint-config-vertexvis",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "The Vertex sharable ESLint config",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/packages/jest-config-vertexvis/package.json
+++ b/packages/jest-config-vertexvis/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@vertexvis/typescript-config-vertexvis": "1.1.0"
+    "@vertexvis/typescript-config-vertexvis": "1.3.0"
   },
   "devDependencies": {
     "@vertexvis/eslint-config-vertexvis-typescript": "0.6.0",

--- a/packages/jest-config-vertexvis/package.json
+++ b/packages/jest-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/jest-config-vertexvis",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "The shared Vertex configs for Jest",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -35,7 +35,7 @@
     "@vertexvis/typescript-config-vertexvis": "1.1.0"
   },
   "devDependencies": {
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.5.2",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.0",
     "eslint": "^8.6.0"
   }
 }

--- a/packages/rollup-plugin-vertexvis-copyright/package.json
+++ b/packages/rollup-plugin-vertexvis-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/rollup-plugin-vertexvis-copyright",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Rollup plugin that prepends a Vertex copyright to JS bundles.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -41,7 +41,7 @@
     "test:coverage": "echo 'No unit tests defined'"
   },
   "devDependencies": {
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.5.2",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.0",
     "@vertexvis/typescript-config-vertexvis": "1.1.0",
     "rollup": "^4.62.2",
     "rollup-plugin-typescript2": "^0.37.0",

--- a/packages/rollup-plugin-vertexvis-copyright/package.json
+++ b/packages/rollup-plugin-vertexvis-copyright/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@vertexvis/eslint-config-vertexvis-typescript": "0.6.0",
-    "@vertexvis/typescript-config-vertexvis": "1.1.0",
+    "@vertexvis/typescript-config-vertexvis": "1.3.0",
     "rollup": "^4.62.2",
     "rollup-plugin-typescript2": "^0.37.0",
     "typescript": "^5.2.0"

--- a/packages/typescript-config-vertexvis/README.md
+++ b/packages/typescript-config-vertexvis/README.md
@@ -19,7 +19,7 @@ project's `package.json`.
 // package.json
 {
   "devDependencies": {
-    "@vertexvis/typescript-config-vertexvis": "0.0.0"
+    "@vertexvis/typescript-config-vertexvis": "1.3.0"
   }
 }
 ```

--- a/packages/typescript-config-vertexvis/package.json
+++ b/packages/typescript-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/typescript-config-vertexvis",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Sharable TypeScript configs for Vertex",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",


### PR DESCRIPTION
## What

Bump version numbers and prep for npm publish

## Areas of Possible Regression

With upgraded dependencies and peer dependencies, there will be regressions if using mismatched versions. 

No longer providing commonjs resouce files in bundles

## Summary

Bumping all versions for sake of new build pipelines and peerDepependency versions even though contents of some packages will not be meaningfully changed 

Additionally because now only providing esm resounces 