### PR TITLE
[PLAT-9119] Publish @vertexvis/prettier-config-vertexvis shareable Prettier config (trailingComma: es5)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
   "semi": true,
   "singleQuote": true,
   "printWidth": 90,
-  "singleAttributePerLine": false
+  "singleAttributePerLine": false,
+  "trailingComma": "es5"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,1 @@
-{
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 90,
-  "singleAttributePerLine": false,
-  "trailingComma": "es5"
-}
+"@vertexvis/prettier-config-vertexvis"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "validate": "yarn build && yarn test && yarn lint"
   },
   "devDependencies": {
+    "@vertexvis/prettier-config-vertexvis": "0.1.0",
     "lerna": "^9.0.7"
   },
   "workspaces": [

--- a/packages/build-tools/LICENSE
+++ b/packages/build-tools/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/eslint-config-vertexvis-typescript/LICENSE
+++ b/packages/eslint-config-vertexvis-typescript/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/eslint-config-vertexvis/LICENSE
+++ b/packages/eslint-config-vertexvis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/jest-config-vertexvis/LICENSE
+++ b/packages/jest-config-vertexvis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/prettier-config-vertexvis/LICENSE
+++ b/packages/prettier-config-vertexvis/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Vertex Software LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prettier-config-vertexvis/LICENSE
+++ b/packages/prettier-config-vertexvis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/prettier-config-vertexvis/README.md
+++ b/packages/prettier-config-vertexvis/README.md
@@ -1,0 +1,51 @@
+# Vertex Prettier Config
+
+This package contains Vertex's sharable [Prettier](https://prettier.io)
+configuration, so our house formatting style (including
+`trailingComma: "es5"`) can be distributed across repos.
+
+## Usage
+
+Add `@vertexvis/prettier-config-vertexvis` and Prettier as `devDependencies` to
+your project's `package.json`.
+
+```json
+// package.json
+{
+  "devDependencies": {
+    "@vertexvis/prettier-config-vertexvis": "0.0.0",
+    "prettier": "^3"
+  }
+}
+```
+
+Then reference this config from the `prettier` key in your `package.json`. No
+separate config file is needed.
+
+```json
+// package.json
+{
+  "prettier": "@vertexvis/prettier-config-vertexvis"
+}
+```
+
+### Overriding the defaults
+
+If you need to override a value, create a `prettier.config.js` file in the root
+of your project that extends this config.
+
+```js
+// prettier.config.js
+import vertexvis from '@vertexvis/prettier-config-vertexvis';
+
+export default {
+  ...vertexvis,
+  printWidth: 100,
+};
+```
+
+## Note on `trailingComma`
+
+Prettier 3 changed the default value of `trailingComma` from `es5` to `all`.
+This config pins it to `es5` so the value is consistent regardless of the
+installed Prettier version.

--- a/packages/prettier-config-vertexvis/index.js
+++ b/packages/prettier-config-vertexvis/index.js
@@ -1,0 +1,17 @@
+/**
+ * Vertex's shared Prettier configuration.
+ *
+ * `trailingComma` is pinned to `es5` so that the value is stable regardless of
+ * the installed Prettier version. Prettier 3 changed the default from `es5` to
+ * `all`; pinning it here keeps Vertex's house style consistent across repos.
+ *
+ * @type {import('prettier').Config}
+ */
+export default {
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  printWidth: 90,
+  singleAttributePerLine: false,
+  trailingComma: 'es5',
+};

--- a/packages/prettier-config-vertexvis/package.json
+++ b/packages/prettier-config-vertexvis/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@vertexvis/prettier-config-vertexvis",
+  "version": "0.1.0",
+  "description": "The shared Vertex config for Prettier",
+  "license": "MIT",
+  "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
+  "homepage": "https://github.com/Vertexvis/vertex-web-tools#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Vertexvis/vertex-web-tools.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Vertexvis/vertex-web-tools/issues"
+  },
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "exit 0",
+    "format": "yarn lint --fix",
+    "lint": "eslint ."
+  },
+  "peerDependencies": {
+    "prettier": ">=3.0.0"
+  },
+  "devDependencies": {
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.1",
+    "eslint": "^8.6.0"
+  }
+}

--- a/packages/rollup-plugin-vertexvis-copyright/LICENSE
+++ b/packages/rollup-plugin-vertexvis-copyright/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/typescript-config-vertexvis/LICENSE
+++ b/packages/typescript-config-vertexvis/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Vertex Software LLC
+Copyright (c) 2020-2026 Vertex Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Publish a **shareable Prettier config**, `@vertexvis/prettier-config-vertexvis`, so Vertex's house formatting style can be distributed across repos instead of being duplicated per project. The config pins `trailingComma: "es5"`, so consumers on Prettier 3 get the intended `es5` style rather than Prettier 3's new `all` default.

## Changes

- **New package** `packages/prettier-config-vertexvis/` — exports the house style (`trailingComma: "es5"` included), mirroring the existing `*-config-vertexvis` packages (package.json, index.js, README, LICENSE).
- **Dogfood in this repo** — the root `.prettierrc.json` now references the shared config (`"@vertexvis/prettier-config-vertexvis"`) instead of listing options inline, and the package is added as a root devDependency.
- **Opportunistic fix** — refreshed the copyright year range to `2020-2026` across all package `LICENSE` files.

## Consumer usage

One line in `package.json`, no config file needed:

```json
{ "prettier": "@vertexvis/prettier-config-vertexvis" }
```

## Why not `eslint-config-prettier`

That package only *disables* ESLint's formatting rules and carries no style options (no `trailingComma` knob) — it can't distribute house style. A shareable Prettier config is the right vehicle and reaches anyone who runs Prettier, not just consumers of our ESLint config. The two are complementary and do not conflict.

## Verification

- Prettier resolves the shared config in this repo (`--find-config-path` → `.prettierrc.json` → package).
- The `es5` pin holds: `packages/build-tools/src/rollup/rollup.ts`, which Prettier 3's `all` default would reformat, is **not** flagged as different.
- New package passes `prettier --check` and `eslint`.

## Ticket

[PLAT-9119](https://vertexvis.atlassian.net/browse/PLAT-9119)

## Release note

New package → needs a version/publish via the repo's `lerna version` release flow when merged.

## Follow-up

[PLAT-9121](https://vertexvis.atlassian.net/browse/PLAT-9121) — adopt this package in vertex-dev-dashboard (blocked by this ticket and PLAT-9101).


[PLAT-9119]: https://vertexvis.atlassian.net/browse/PLAT-9119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ