### PR TITLE
Release Changes

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/build-tools",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Build tools for web development",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -51,15 +51,15 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
-    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.5.1",
+    "@vertexvis/rollup-plugin-vertexvis-copyright": "0.5.2",
     "rollup-plugin-typescript2": "^0.37.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^22.20.0",
     "@types/rollup-plugin-peer-deps-external": "^2.2.6",
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.1",
-    "@vertexvis/jest-config-vertexvis": "0.6.1",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.2",
+    "@vertexvis/jest-config-vertexvis": "0.6.2",
     "eslint": "^8.6.0",
     "jest": "^30.4.2",
     "rollup": "^4.62.2",

--- a/packages/eslint-config-vertexvis-typescript/package.json
+++ b/packages/eslint-config-vertexvis-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/eslint-config-vertexvis-typescript",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The Vertex sharable ESLint config for TypeScript.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -32,7 +32,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.62.1",
-    "@vertexvis/eslint-config-vertexvis": "0.8.1",
+    "@vertexvis/eslint-config-vertexvis": "0.8.2",
     "eslint-config-prettier": "^10.1.8"
   },
   "devDependencies": {

--- a/packages/eslint-config-vertexvis/package.json
+++ b/packages/eslint-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/eslint-config-vertexvis",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The Vertex sharable ESLint config",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",

--- a/packages/jest-config-vertexvis/package.json
+++ b/packages/jest-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/jest-config-vertexvis",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The shared Vertex configs for Jest",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -32,10 +32,10 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@vertexvis/typescript-config-vertexvis": "1.3.1"
+    "@vertexvis/typescript-config-vertexvis": "1.3.2"
   },
   "devDependencies": {
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.1",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.2",
     "eslint": "^8.6.0"
   }
 }

--- a/packages/prettier-config-vertexvis/package.json
+++ b/packages/prettier-config-vertexvis/package.json
@@ -31,7 +31,7 @@
     "prettier": ">=3.0.0"
   },
   "devDependencies": {
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.1",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.2",
     "eslint": "^8.6.0"
   }
 }

--- a/packages/rollup-plugin-vertexvis-copyright/package.json
+++ b/packages/rollup-plugin-vertexvis-copyright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/rollup-plugin-vertexvis-copyright",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Rollup plugin that prepends a Vertex copyright to JS bundles.",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",
@@ -41,8 +41,8 @@
     "test:coverage": "echo 'No unit tests defined'"
   },
   "devDependencies": {
-    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.1",
-    "@vertexvis/typescript-config-vertexvis": "1.3.1",
+    "@vertexvis/eslint-config-vertexvis-typescript": "0.6.2",
+    "@vertexvis/typescript-config-vertexvis": "1.3.2",
     "rollup": "^4.62.2",
     "rollup-plugin-typescript2": "^0.37.0",
     "typescript": "^5.2.0"

--- a/packages/typescript-config-vertexvis/package.json
+++ b/packages/typescript-config-vertexvis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vertexvis/typescript-config-vertexvis",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Sharable TypeScript configs for Vertex",
   "license": "MIT",
   "author": "Vertex Developers <support@vertexvis.com> (https://developer.vertexvis.com)",


### PR DESCRIPTION
## Release Changes

Version bumps generated by `lerna version` (via `yarn release`). Merging to `master` triggers the `publish` job in `branch.yml`, which publishes the changed packages to npm and tags each version.

### New package
- `@vertexvis/prettier-config-vertexvis` **0.1.0** — initial release of the shareable Prettier config (pins `trailingComma: "es5"`). See PLAT-9119 / #111.

### Patch bumps (2020-2026 LICENSE copyright refresh + cascaded internal dep ranges)
- `@vertexvis/build-tools` 0.11.1 → **0.11.2**
- `@vertexvis/eslint-config-vertexvis` 0.8.1 → **0.8.2**
- `@vertexvis/eslint-config-vertexvis-typescript` 0.6.1 → **0.6.2**
- `@vertexvis/jest-config-vertexvis` 0.6.1 → **0.6.2**
- `@vertexvis/rollup-plugin-vertexvis-copyright` 0.5.1 → **0.5.2**
- `@vertexvis/typescript-config-vertexvis` 1.3.1 → **1.3.2**

### Ticket
[PLAT-9119](https://vertexvis.atlassian.net/browse/PLAT-9119)


[PLAT-9119]: https://vertexvis.atlassian.net/browse/PLAT-9119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ